### PR TITLE
CRS information now appends to outputs - ref: Issue #21

### DIFF
--- a/algorithms/extract_vw_algorithm.py
+++ b/algorithms/extract_vw_algorithm.py
@@ -86,7 +86,8 @@ class ExtractVWAlgorithm(QgsProcessingAlgorithm):
         valley_lines = self.parameterAsVectorLayer(parameters, self.VALLEY_LINES, context)
         stream_network = self.parameterAsVectorLayer(parameters, self.STREAM_NETWORK, context)
 
-        crs = transects.sourceCrs().authid()
+        centers_crs = center.sourceCrs()
+        crs = centers_crs.authid()
 
         def create_output_layer(name):
             fields = QgsFields()
@@ -125,6 +126,9 @@ class ExtractVWAlgorithm(QgsProcessingAlgorithm):
         # Compute valley widths and get updated layer
         center_updated1 = compute_valley_width(center, left1, right1, out_field="VFW")
         center_updated2 = compute_valley_width(center_updated1, left2, right2, out_field="VW")
+
+        if center_updated2.isValid():
+            center_updated2.setCrs(centers_crs)
 
         self.save_output_layer(center_updated2, parameters, self.CENTER_OUT, context)
 


### PR DESCRIPTION
Issue #21 identified a problem where outputs generated by extract_vw_algorithm.py did not contain CRS information. Although the subsequent calculations of the parameters VW, VFW, LVS, and RVS did not appear to be affected by this, the lack of CRS information is problematic for any layer generated by the plugin, as users may want to use the layers in a different instance or on other software. 

The fix is to ensure all output layers inherit the CRS from the input [2] Segment Centers layer.

To ensure CRS information was added to VW and VFW layers generated in the algorithm, we added to lines 89-90:
```
centers_crs = center.sourceCrs()    
crs = centers_crs.authid()
```

We also added a subsequent check to lines 130-131 to ensure the new segment centers layer would also contain a CRS,
```
if center_updated2.isValid():
      center_updated2.setCrs(centers_crs)
```