### PR TITLE
Fix to DVS producing negative values. Ref: Issue #25

### DIFF
--- a/algorithms/extract_dvs_sin_algorithm.py
+++ b/algorithms/extract_dvs_sin_algorithm.py
@@ -114,7 +114,12 @@ class ExtractDVSAlgorithm(QgsProcessingAlgorithm):
             length = geom.length()
             straight = math.hypot(end.x() - start.x(), end.y() - start.y())
 
-            dvs = ((elev_start - elev_end) / length) * 100 if length > 0 else None
+            if length > 0:
+                dvs = ((elev_start - elev_end) / length) * 100
+                dvs = max(dvs, 0.00001)
+            else:
+                dvs = None
+                
             sin = (length / straight) if straight > 0 else None
 
             out_layer.changeAttributeValue(feat.id(), dvs_idx, dvs)


### PR DESCRIPTION
[5] Extract DVS and SIN now uses a conditional to, in the case of DVS < 0.00001, assign the DVS = 0.00001. This small positive value captures that the DVS is extremely low, yet still maintains a positive value so as to capture the physical process of the stream flowing from upstream to downstream. This is necessary because the algorithm calculates DVS between the elevation of the most upstream and downstream point with a river segment, which can plausibly have elevational changes that are negative, especially in the case where river segments start and end in very short segments.